### PR TITLE
remove multiple setState functions in favour of one updateState function

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -907,7 +907,7 @@ class App extends React.Component {
         //ui feedback
         this.setSnackBar(response.info);
         //close the resend password dialog
-        this.closeResendPasswordDialog();
+        this.updateState({ resendPasswordDialogOpen: false });
       })
       .catch((error) => {
         //do something
@@ -1423,9 +1423,12 @@ class App extends React.Component {
       //ui feedback
       this.setSnackBar(response.info);
       //close the register dialog
-      this.closeRegisterDialog();
       //enter the new users name in the username box and a blank password
-      this.setState({ user: user, password: "" });
+      this.updateState({
+        registerDialogOpen: false,
+        user: user,
+        password: "",
+      });
     });
   }
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3390,8 +3393,10 @@ class App extends React.Component {
 
   //previews the planning grid
   previewPlanningGrid(planning_grid_metadata) {
-    this.setState({ planning_grid_metadata: planning_grid_metadata });
-    this.openPlanningGridDialog();
+    this.setState({
+      planning_grid_metadata: planning_grid_metadata,
+      planningGridDialogOpen: true,
+    });
   }
 
   //creates a new planning grid unit
@@ -3411,7 +3416,7 @@ class App extends React.Component {
       )
         .then((message) => {
           this.newPlanningGridCreated(message).then(() => {
-            this.closeNewPlanningGridDialog();
+            this.updateState({ NewPlanningGridDialogOpen: false });
             //websocket has finished
             resolve(message);
           });
@@ -3440,7 +3445,7 @@ class App extends React.Component {
             info: response.info,
           });
           this.newPlanningGridCreated(response).then(() => {
-            this.closeImportPlanningGridDialog();
+            this.updateState({ importPlanningGridDialogOpen: false });
           });
         })
         .catch((error) => {
@@ -3627,9 +3632,7 @@ class App extends React.Component {
     //reset state
     if (timers.length === 0) this.setState({ uploading: false });
   }
-  closeWelcomeDialog() {
-    this.setState({ welcomeDialogOpen: false });
-  }
+
   openWelcomeDialog() {
     this.parseNotifications();
     this.setState({ welcomeDialogOpen: true });
@@ -3647,38 +3650,15 @@ class App extends React.Component {
     });
     if (showClearSelectAll) this.getSelectedFeatureIds();
   }
-  closeFeaturesDialog() {
-    this.setState({
-      featuresDialogOpen: false,
-      newFeaturePopoverOpen: false,
-      importFeaturePopoverOpen: false,
-    });
+
+  updateState(state_obj) {
+    this.setState(state_obj);
   }
-  openNewFeatureDialog() {
-    this.setState({ NewFeatureDialogOpen: true });
-  }
+
   closeNewFeatureDialog() {
     this.setState({ NewFeatureDialogOpen: false });
     //finalise digitising
     this.finaliseDigitising();
-  }
-  openImportFromWebDialog() {
-    this.setState({ importFromWebDialogOpen: true });
-  }
-  closeImportFromWebDialog() {
-    this.setState({ importFromWebDialogOpen: false });
-  }
-  openImportFeaturesDialog() {
-    this.setState({ importFeaturesDialogOpen: true });
-  }
-  closeImportFeaturesDialog() {
-    this.setState({ importFeaturesDialogOpen: false });
-  }
-  openImportGBIFDialog() {
-    this.setState({ importGBIFDialogOpen: true });
-  }
-  closeImportGBIFDialog() {
-    this.setState({ importGBIFDialogOpen: false });
   }
   openPlanningGridsDialog() {
     //refresh the planning grids if we are using a hosted service - other users could have created/deleted items
@@ -3686,60 +3666,7 @@ class App extends React.Component {
       this.getPlanningUnitGrids();
     this.setState({ planningGridsDialogOpen: true });
   }
-  closePlanningGridsDialog() {
-    this.setState({ planningGridsDialogOpen: false });
-  }
-  openPlanningGridDialog() {
-    this.setState({ planningGridDialogOpen: true });
-  }
-  closePlanningGridDialog() {
-    this.setState({ planningGridDialogOpen: false });
-  }
-  openFeatureDialog() {
-    this.setState({ featureDialogOpen: true });
-  }
-  closeFeatureDialog() {
-    this.setState({ featureDialogOpen: false });
-  }
-  showNewFeaturePopover() {
-    this.setState({ newFeaturePopoverOpen: true });
-  }
-  hideNewFeaturePopover() {
-    this.setState({ newFeaturePopoverOpen: false });
-  }
-  showImportFeaturePopover() {
-    this.setState({ importFeaturePopoverOpen: true });
-  }
-  hideImportFeaturePopover() {
-    this.setState({ importFeaturePopoverOpen: false });
-  }
-  showImportProjectPopover() {
-    this.setState({ importProjectPopoverOpen: true });
-  }
-  hideImportProjectPopover() {
-    this.setState({ importProjectPopoverOpen: false });
-  }
-  openCostsDialog() {
-    this.setState({ costsDialogOpen: true });
-  }
-  closeCostsDialog() {
-    this.setState({ costsDialogOpen: false });
-  }
-  openImportCostsDialog() {
-    this.setState({ importCostsDialogOpen: true });
-  }
-  closeImportCostsDialog() {
-    this.setState({ importCostsDialogOpen: false });
-  }
-  openWDPAUpdateDialog() {
-    this.setState({ updateWDPADialogOpen: true });
-  }
-  closeWDPAUpdateDialog() {
-    this.setState({ updateWDPADialogOpen: false });
-  }
-  setNewFeatureDatasetFilename(filename) {
-    this.setState({ featureDatasetFilename: filename });
-  }
+
   //used by the import wizard to import a users zipped shapefile as the planning units
   importZippedShapefileAsPu(zipname, alias, description) {
     //the zipped shapefile has been uploaded to the MARXAN folder - it will be imported to PostGIS and a record will be entered in the metadata_planning_units table
@@ -3829,7 +3756,7 @@ class App extends React.Component {
   //called when the user has drawn a polygon on screen
   polygonDrawn(evt) {
     //open the new feature dialog for the metadata
-    this.openNewFeatureDialog();
+    this.updateState({ NewFeatureDialogOpen: true });
     //save the feature in a local variable
     this.digitisedFeatures = evt.features;
   }
@@ -3840,17 +3767,7 @@ class App extends React.Component {
     this.state.allFeatures.forEach((feature) => {
       ids.push(feature.id);
     });
-    this.selectFeatures(ids);
-  }
-
-  //clears all the Conservation features
-  clearAllFeatures() {
-    this.setState({ selectedFeatureIds: [] });
-  }
-
-  //selects features
-  selectFeatures(ids) {
-    this.setState({ selectedFeatureIds: ids });
+    this.updateState({ selectedFeatureIds: ids });
   }
 
   //updates the allFeatures to set the various properties based on which features have been selected in the FeaturesDialog or programmatically
@@ -3888,7 +3805,11 @@ class App extends React.Component {
       //persist the changes to the server
       if (this.state.userData.ROLE !== "ReadOnly") this.updateSpecFile();
       //close the dialog
-      this.closeFeaturesDialog();
+      this.updateState({
+        featuresDialogOpen: false,
+        newFeaturePopoverOpen: false,
+        importFeaturePopoverOpen: false,
+      });
     });
   }
 
@@ -3931,8 +3852,10 @@ class App extends React.Component {
 
   //previews the feature
   previewFeature(feature_metadata) {
-    this.setState({ feature_metadata: feature_metadata });
-    this.openFeatureDialog();
+    this.setState({
+      feature_metadata: feature_metadata,
+      featureDialogOpen: true,
+    });
   }
 
   //unzips a shapefile on the server
@@ -4496,59 +4419,20 @@ class App extends React.Component {
   hideToolsMenu(e) {
     this.setState({ toolsMenuOpen: false });
   }
-  openRegisterDialog() {
-    this.setState({ registerDialogOpen: true });
-  }
-  closeRegisterDialog() {
-    this.setState({ registerDialogOpen: false });
-  }
-  openResendPasswordDialog() {
-    this.setState({ resendPasswordDialogOpen: true });
-  }
-  closeResendPasswordDialog() {
-    this.setState({ resendPasswordDialogOpen: false });
-  }
+
   openProjectsDialog() {
     this.setState({ projectsDialogOpen: true });
     this.getProjects();
   }
-  closeProjectsDialog() {
-    this.setState({
-      projectsDialogOpen: false,
-      importProjectPopoverOpen: false,
-    });
-  }
-  openNewProjectDialog() {
-    this.setState({ newProjectDialogOpen: true });
-  }
-  closeNewProjectDialog() {
-    this.setState({ newProjectDialogOpen: false });
-  }
+
   openNewProjectWizardDialog() {
     this.getCountries();
     this.setState({ newProjectWizardDialogOpen: true });
   }
-  closeNewProjectWizardDialog() {
-    this.setState({ newProjectWizardDialogOpen: false });
-  }
+
   openNewPlanningGridDialog() {
     this.getCountries();
     this.setState({ NewPlanningGridDialogOpen: true });
-  }
-  closeNewPlanningGridDialog() {
-    this.setState({ NewPlanningGridDialogOpen: false });
-  }
-  openImportPlanningGridDialog() {
-    this.setState({ importPlanningGridDialogOpen: true });
-  }
-  closeImportPlanningGridDialog() {
-    this.setState({ importPlanningGridDialogOpen: false });
-  }
-  openInfoDialog() {
-    this.setState({ openInfoDialogOpen: true, featureMenuOpen: false });
-  }
-  closeInfoDialog() {
-    this.setState({ openInfoDialogOpen: false });
   }
 
   openUserSettingsDialog() {
@@ -4556,33 +4440,14 @@ class App extends React.Component {
     this.hideUserMenu();
   }
 
-  closeUserSettingsDialog() {
-    this.setState({ UserSettingsDialogOpen: false });
-  }
-
   openProfileDialog() {
     this.setState({ profileDialogOpen: true });
     this.hideUserMenu();
-  }
-  closeProfileDialog() {
-    this.setState({ profileDialogOpen: false });
   }
 
   openAboutDialog() {
     this.setState({ aboutDialogOpen: true });
     this.hideHelpMenu();
-  }
-
-  closeAboutDialog() {
-    this.setState({ aboutDialogOpen: false });
-  }
-
-  showRunSettingsDialog() {
-    this.setState({ settingsDialogOpen: true });
-  }
-
-  closeRunSettingsDialog() {
-    this.setState({ settingsDialogOpen: false });
   }
 
   openClassificationDialog() {
@@ -4592,33 +4457,9 @@ class App extends React.Component {
     this.setState({ classificationDialogOpen: false });
   }
 
-  openImportProjectDialog() {
-    this.setState({ importProjectDialogOpen: true });
-  }
-  closeImportDialog() {
-    this.setState({ importProjectDialogOpen: false });
-  }
-  openImportMXWDialog() {
-    this.setState({ importMXWDialogOpen: true });
-  }
-  closeImportMXWDialog() {
-    this.setState({ importMXWDialogOpen: false });
-  }
   openUsersDialog() {
     this.getUsers();
     this.setState({ usersDialogOpen: true });
-  }
-  closeUsersDialog() {
-    this.setState({ usersDialogOpen: false });
-  }
-  closeAlertDialog() {
-    this.setState({ alertDialogOpen: false });
-  }
-  hideResults() {
-    this.setState({ resultsPanelOpen: false });
-  }
-  showResults() {
-    this.setState({ resultsPanelOpen: true });
   }
 
   toggleInfoPanel() {
@@ -4636,12 +4477,6 @@ class App extends React.Component {
   closeRunLogDialog() {
     this.stopPollingRunLogs();
     this.setState({ runLogDialogOpen: false });
-  }
-  openResetDialog() {
-    this.setState({ resetDialogOpen: true });
-  }
-  closeResetDialog() {
-    this.setState({ resetDialogOpen: false });
   }
   openGapAnalysisDialog() {
     this.setState({ gapAnalysisDialogOpen: true, gapAnalysis: [] });
@@ -4677,27 +4512,15 @@ class App extends React.Component {
         projectListDialogHeading: projectListDialogHeading,
       },
       () => {
-        this.openProjectsListDialog();
+        this.updateState({ ProjectsListDialogOpen: true });
       }
     );
-  }
-  openProjectsListDialog() {
-    this.setState({ ProjectsListDialogOpen: true });
-  }
-  closeProjectsListDialog() {
-    this.setState({ ProjectsListDialogOpen: false });
   }
   openTargetDialog() {
     this.setState({ targetDialogOpen: true });
   }
   closeTargetDialog() {
     this.setState({ targetDialogOpen: false });
-  }
-  openShareableLinkDialog() {
-    this.setState({ shareableLinkDialogOpen: true });
-  }
-  closeShareableLinkDialog() {
-    this.setState({ shareableLinkDialogOpen: false });
   }
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   ////////////////////////// PROTECTED AREAS LAYERS STUFF
@@ -4725,7 +4548,8 @@ class App extends React.Component {
     let filterExpr = ["all", ["in", "iucn_cat"].concat(iucnCategories)]; // no longer filter by ISO code
     this.map.setFilter(CONSTANTS.WDPA_LAYER_NAME, filterExpr);
     //turn on/off the protected areas legend
-    iucnCategory === "None" ? this.hidePALegend() : this.showPALegend();
+    let layer = iucnCategory === "None" ? false : true;
+    this.setState({ pa_layer_visible: layer });
   }
 
   getIndividualIucnCategories(iucnCategory) {
@@ -4841,15 +4665,6 @@ class App extends React.Component {
     });
   }
 
-  //turns on the legend for the protected areas
-  showPALegend() {
-    this.setState({ pa_layer_visible: true });
-  }
-
-  //hides the protected area legend
-  hidePALegend() {
-    this.setState({ pa_layer_visible: false });
-  }
   preprocessProtectedAreas(iucnCategory) {
     //have the intersections already been calculated
     if (this.state.protected_area_intersections.length > 0) {
@@ -4932,7 +4747,7 @@ class App extends React.Component {
             //recalculate the protected area intersections and refilter the vector tiles
             this.changeIucnCategory(this.state.metadata.IUCN_CATEGORY);
             //close the dialog
-            this.closeWDPAUpdateDialog();
+            this.updateState({ updateWDPADialogOpen: false });
           });
           resolve(message);
         })
@@ -5153,7 +4968,7 @@ class App extends React.Component {
   }
 
   getShareableLink() {
-    this.openShareableLinkDialog();
+    this.updateState({ shareableLinkDialogOpen: true });
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -5269,7 +5084,7 @@ class App extends React.Component {
         //delete the cost file
         this.deleteCost(costname).then((_) => {
           //close the import costs dialog
-          this.closeImportCostsDialog();
+          this.updateState({ importCostsDialogOpen: false });
           resolve();
         });
       } else {
@@ -5319,11 +5134,11 @@ class App extends React.Component {
         .then((message) => {
           //websocket has finished
           resolve(message);
-          this.closeResetDialog();
+          this.updateState({ resetDialogOpen: false });
         })
         .catch((error) => {
           reject(error);
-          this.closeResetDialog();
+          this.updateState({ resetDialogOpen: false });
         });
     });
   }
@@ -5359,13 +5174,13 @@ class App extends React.Component {
           <LoginDialog
             open={!this.state.loggedIn}
             onOk={this.validateUser.bind(this)}
-            onCancel={this.openRegisterDialog.bind(this)}
+            onCancel={() => this.updateState({ registerDialogOpen: true })}
             loading={this.state.loading}
             user={this.state.user}
             password={this.state.password}
             changeUserName={this.changeUserName.bind(this)}
             changePassword={this.changePassword.bind(this)}
-            openResendPasswordDialog={this.openResendPasswordDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             marxanServers={this.state.marxanServers}
             selectServer={this.selectServer.bind(this)}
             marxanServer={this.state.marxanServer}
@@ -5374,13 +5189,15 @@ class App extends React.Component {
           <RegisterDialog
             open={this.state.registerDialogOpen}
             onOk={this.createNewUser.bind(this)}
-            onCancel={this.closeRegisterDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             loading={this.state.loading}
           />
           <ResendPasswordDialog
             open={this.state.resendPasswordDialogOpen}
             onOk={this.resendPassword.bind(this)}
-            onCancel={this.closeResendPasswordDialog.bind(this)}
+            onCancel={() =>
+              this.updateState({ resendPasswordDialogOpen: false })
+            }
             loading={this.state.loading}
             changeEmail={this.changeEmail.bind(this)}
             email={this.state.resendEmail}
@@ -5390,8 +5207,8 @@ class App extends React.Component {
               this.state.userData.SHOWWELCOMESCREEN &&
               this.state.welcomeDialogOpen
             }
-            onOk={this.closeWelcomeDialog.bind(this)}
-            onCancel={this.closeWelcomeDialog.bind(this)}
+            onOk={this.updateState.bind(this)}
+            onCancel={() => this.updateState({ welcomeDialogOpen: false })}
             userData={this.state.userData}
             saveOptions={this.saveOptions.bind(this)}
             notifications={this.state.notifications}
@@ -5406,7 +5223,7 @@ class App extends React.Component {
             openUsersDialog={this.openUsersDialog.bind(this)}
             openRunLogDialog={this.openRunLogDialog.bind(this)}
             openGapAnalysisDialog={this.openGapAnalysisDialog.bind(this)}
-            openResetDialog={this.openResetDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             userRole={this.state.userData.ROLE}
             marxanServer={this.state.marxanServer}
             metadata={this.state.metadata}
@@ -5432,8 +5249,8 @@ class App extends React.Component {
           />
           <UserSettingsDialog
             open={this.state.UserSettingsDialogOpen}
-            onOk={this.closeUserSettingsDialog.bind(this)}
-            onCancel={this.closeUserSettingsDialog.bind(this)}
+            onOk={() => this.updateState({ UserSettingsDialogOpen: false })}
+            onCancel={() => this.updateState({ UserSettingsDialogOpen: false })}
             loading={this.state.loading}
             userData={this.state.userData}
             saveOptions={this.saveOptions.bind(this)}
@@ -5443,8 +5260,8 @@ class App extends React.Component {
           />
           <UsersDialog
             open={this.state.usersDialogOpen}
-            onOk={this.closeUsersDialog.bind(this)}
-            onCancel={this.closeUsersDialog.bind(this)}
+            onOk={() => this.updateState({ usersDialogOpen: false })}
+            onCancel={() => this.updateState({ usersDialogOpen: false })}
             loading={this.state.loading}
             user={this.state.user}
             users={this.state.users}
@@ -5455,15 +5272,15 @@ class App extends React.Component {
           />
           <ProfileDialog
             open={this.state.profileDialogOpen}
-            onOk={this.closeProfileDialog.bind(this)}
-            onCancel={this.closeProfileDialog.bind(this)}
+            onOk={() => this.updateState({ profileDialogOpen: false })}
+            onCancel={() => this.updateState({ profileDialogOpen: false })}
             loading={this.state.loading}
             userData={this.state.userData}
             updateUser={this.updateUser.bind(this)}
           />
           <AboutDialog
             open={this.state.aboutDialogOpen}
-            onOk={this.closeAboutDialog.bind(this)}
+            onOk={() => this.updateState({ aboutDialogOpen: false })}
             marxanClientReleaseVersion={MARXAN_CLIENT_VERSION}
             wdpaAttribution={this.state.wdpaAttribution}
           />
@@ -5487,7 +5304,6 @@ class App extends React.Component {
             stopPuEditSession={this.stopPuEditSession.bind(this)}
             puEditing={this.state.puEditing}
             clearManualEdits={this.clearManualEdits.bind(this)}
-            showRunSettingsDialog={this.showRunSettingsDialog.bind(this)}
             openFeatureMenu={this.openFeatureMenu.bind(this)}
             preprocessing={this.state.preprocessing}
             openFeaturesDialog={this.openFeaturesDialog.bind(this)}
@@ -5507,7 +5323,7 @@ class App extends React.Component {
             changeCostname={this.changeCostname.bind(this)}
             loadCostsLayer={this.loadCostsLayer.bind(this)}
             loading={this.state.loading}
-            openCostsDialog={this.openCostsDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             protected_area_intersections={
               this.state.protected_area_intersections
             }
@@ -5518,7 +5334,6 @@ class App extends React.Component {
             solutions={this.state.solutions}
             loadSolution={this.loadSolution.bind(this)}
             openClassificationDialog={this.openClassificationDialog.bind(this)}
-            hideResults={this.hideResults.bind(this)}
             brew={this.state.brew}
             messages={this.state.logMessages}
             activeResultsTab={this.state.activeResultsTab}
@@ -5536,8 +5351,8 @@ class App extends React.Component {
           />
           <FeatureInfoDialog
             open={this.state.openInfoDialogOpen}
-            onOk={this.closeInfoDialog.bind(this)}
-            onCancel={this.closeInfoDialog.bind(this)}
+            onOk={() => this.updateState({ openInfoDialogOpen: false })}
+            onCancel={() => this.updateState({ openInfoDialogOpen: false })}
             loading={this.state.loading}
             feature={this.state.currentFeature}
             updateFeature={this.updateFeature.bind(this)}
@@ -5557,54 +5372,52 @@ class App extends React.Component {
           />
           <ProjectsDialog
             open={this.state.projectsDialogOpen}
-            onOk={this.closeProjectsDialog.bind(this)}
-            onCancel={this.closeProjectsDialog.bind(this)}
+            onCancel={() =>
+              this.updateState({
+                projectsDialogOpen: false,
+                importProjectPopoverOpen: false,
+              })
+            }
             loading={this.state.loading}
             projects={this.state.projects}
             oldVersion={this.state.metadata.OLDVERSION}
+            updateState={this.updateState.bind(this)}
             deleteProject={this.deleteProject.bind(this)}
             loadProject={this.loadProject.bind(this)}
             exportProject={this.exportProject.bind(this)}
             cloneProject={this.cloneProject.bind(this)}
-            openNewProjectDialog={this.openNewProjectDialog.bind(this)}
-            openImportProjectDialog={this.openImportProjectDialog.bind(this)}
             unauthorisedMethods={this.state.unauthorisedMethods}
             userRole={this.state.userData.ROLE}
             getAllFeatures={this.getAllFeatures.bind(this)}
             importProjectPopoverOpen={this.state.importProjectPopoverOpen}
-            showImportProjectPopover={this.showImportProjectPopover.bind(this)}
-            hideImportProjectPopover={this.hideImportProjectPopover.bind(this)}
-            openImportMXWDialog={this.openImportMXWDialog.bind(this)}
-            closeImportMXWDialog={this.closeImportMXWDialog.bind(this)}
             importMXWDialogOpen={this.state.importMXWDialogOpen}
           />
           <NewProjectDialog
             open={this.state.newProjectDialogOpen}
             registry={this.state.registry}
-            onOk={this.closeNewProjectDialog.bind(this)}
             loading={this.state.loading}
             getPlanningUnitGrids={this.getPlanningUnitGrids.bind(this)}
             planning_unit_grids={this.state.planning_unit_grids}
             openFeaturesDialog={this.openFeaturesDialog.bind(this)}
             features={this.state.allFeatures}
-            openCostsDialog={this.openCostsDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             selectedCosts={this.state.selectedCosts}
             createNewProject={this.createNewProject.bind(this)}
             previewFeature={this.previewFeature.bind(this)}
           />
           <NewProjectWizardDialog
             open={this.state.newProjectWizardDialogOpen}
-            onOk={this.closeNewProjectWizardDialog.bind(this)}
+            onOk={() => this.updateState({ newProjectWizardDialogOpen: false })}
             okDisabled={true}
             countries={this.state.countries}
-            closeNewProjectWizardDialog={this.closeNewProjectWizardDialog.bind(
-              this
-            )}
+            updateState={this.updateState.bind(this)}
             createNewNationalProject={this.createNewNationalProject.bind(this)}
           />
           <NewPlanningGridDialog
             open={this.state.NewPlanningGridDialogOpen}
-            onCancel={this.closeNewPlanningGridDialog.bind(this)}
+            onCancel={() =>
+              this.updateState({ NewPlanningGridDialogOpen: false })
+            }
             loading={
               this.state.loading ||
               this.state.preprocessing ||
@@ -5619,43 +5432,35 @@ class App extends React.Component {
           <ImportPlanningGridDialog
             open={this.state.importPlanningGridDialogOpen}
             onOk={this.importPlanningUnitGrid.bind(this)}
-            onCancel={this.closeImportPlanningGridDialog.bind(this)}
+            onCancel={() =>
+              this.updateState({ importPlanningGridDialogOpen: false })
+            }
             loading={this.state.loading || this.state.uploading}
             fileUpload={this.uploadFileToFolder.bind(this)}
           />
           <FeaturesDialog
             open={this.state.featuresDialogOpen}
             onOk={this.updateSelectedFeatures.bind(this)}
-            onCancel={this.closeFeaturesDialog.bind(this)}
             loading={this.state.loading || this.state.uploading}
             metadata={this.state.metadata}
             allFeatures={this.state.allFeatures}
             deleteFeature={this.deleteFeature.bind(this)}
-            openImportFeaturesDialog={this.openImportFeaturesDialog.bind(this)}
-            openImportFromWebDialog={this.openImportFromWebDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             selectAllFeatures={this.selectAllFeatures.bind(this)}
-            clearAllFeatures={this.clearAllFeatures.bind(this)}
-            selectFeatures={this.selectFeatures.bind(this)}
             userRole={this.state.userData.ROLE}
             clickFeature={this.clickFeature.bind(this)}
             addingRemovingFeatures={this.state.addingRemovingFeatures}
             selectedFeatureIds={this.state.selectedFeatureIds}
             initialiseDigitising={this.initialiseDigitising.bind(this)}
             newFeaturePopoverOpen={this.state.newFeaturePopoverOpen}
-            hideNewFeaturePopover={this.hideNewFeaturePopover.bind(this)}
-            showNewFeaturePopover={this.showNewFeaturePopover.bind(this)}
             importFeaturePopoverOpen={this.state.importFeaturePopoverOpen}
-            hideImportFeaturePopover={this.hideImportFeaturePopover.bind(this)}
-            showImportFeaturePopover={this.showImportFeaturePopover.bind(this)}
             previewFeature={this.previewFeature.bind(this)}
-            openImportGBIFDialog={this.openImportGBIFDialog.bind(this)}
             marxanServer={this.state.marxanServer}
             refreshFeatures={this.refreshFeatures.bind(this)}
           />
           <FeatureDialog
             open={this.state.featureDialogOpen}
-            onOk={this.closeFeatureDialog.bind(this)}
-            onCancel={this.closeFeatureDialog.bind(this)}
+            onOk={() => this.updateState({ featureDialogOpen: false })}
             loading={this.state.loading}
             feature_metadata={this.state.feature_metadata}
             getTilesetMetadata={this.getMetadata.bind(this)}
@@ -5675,13 +5480,12 @@ class App extends React.Component {
           <ImportFeaturesDialog
             open={this.state.importFeaturesDialogOpen}
             importFeatures={this.importFeatures.bind(this)}
-            onCancel={this.closeImportFeaturesDialog.bind(this)}
             loading={
               this.state.loading ||
               this.state.preprocessing ||
               this.state.uploading
             }
-            setFilename={this.setNewFeatureDatasetFilename.bind(this)}
+            updateState={this.updateState.bind(this)}
             filename={this.state.featureDatasetFilename}
             fileUpload={this.uploadFileToFolder.bind(this)}
             unzipShapefile={this.unzipShapefile.bind(this)}
@@ -5692,7 +5496,7 @@ class App extends React.Component {
           />
           <ImportFromWebDialog
             open={this.state.importFromWebDialogOpen}
-            onCancel={this.closeImportFromWebDialog.bind(this)}
+            onCancel={this.updateState.bind(this)}
             loading={
               this.state.loading ||
               this.state.preprocessing ||
@@ -5704,7 +5508,7 @@ class App extends React.Component {
           />
           <ImportGBIFDialog
             open={this.state.importGBIFDialogOpen}
-            onCancel={this.closeImportGBIFDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             loading={
               this.state.loading ||
               this.state.preprocessing ||
@@ -5717,16 +5521,12 @@ class App extends React.Component {
           />
           <PlanningGridsDialog
             open={this.state.planningGridsDialogOpen}
-            onOk={this.closePlanningGridsDialog.bind(this)}
-            onCancel={this.closePlanningGridsDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             loading={this.state.loading}
             getPlanningUnitGrids={this.getPlanningUnitGrids.bind(this)}
             unauthorisedMethods={this.state.unauthorisedMethods}
             planningGrids={this.state.planning_unit_grids}
             openNewPlanningGridDialog={this.openNewPlanningGridDialog.bind(
-              this
-            )}
-            openImportPlanningGridDialog={this.openImportPlanningGridDialog.bind(
               this
             )}
             exportPlanningGrid={this.exportPlanningGrid.bind(this)}
@@ -5736,8 +5536,8 @@ class App extends React.Component {
           />
           <PlanningGridDialog
             open={this.state.planningGridDialogOpen}
-            onOk={this.closePlanningGridDialog.bind(this)}
-            onCancel={this.closePlanningGridDialog.bind(this)}
+            onOk={() => this.updateState({ planningGridDialogOpen: false })}
+            updateState={this.updateState.bind(this)}
             loading={this.state.loading}
             planning_grid_metadata={this.state.planning_grid_metadata}
             getTilesetMetadata={this.getMetadata.bind(this)}
@@ -5748,32 +5548,32 @@ class App extends React.Component {
             open={this.state.ProjectsListDialogOpen}
             projects={this.state.projectList}
             userRole={this.state.userData.ROLE}
-            onOk={this.closeProjectsListDialog.bind(this)}
+            onOk={() => this.updateState({ ProjectsListDialogOpen: false })}
             title={this.state.projectListDialogTitle}
             heading={this.state.projectListDialogHeading}
           />
           <CostsDialog
             open={this.state.costsDialogOpen}
-            onOk={this.closeCostsDialog.bind(this)}
-            onCancel={this.closeCostsDialog.bind(this)}
+            onOk={() => this.updateState({ costsDialogOpen: false })}
+            onCancel={() => this.updateState({ costsDialogOpen: false })}
+            updateState={this.updateState.bind(this)}
             unauthorisedMethods={this.state.unauthorisedMethods}
             costname={this.state.metadata.COSTS}
-            openImportCostsDialog={this.openImportCostsDialog.bind(this)}
             deleteCost={this.deleteCost.bind(this)}
             data={this.state.costnames}
           />
           <ImportCostsDialog
             open={this.state.importCostsDialogOpen}
             addCost={this.addCost.bind(this)}
-            closeImportCostsDialog={this.closeImportCostsDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             deleteCostFileThenClose={this.deleteCostFileThenClose.bind(this)}
             loading={this.state.loading}
             fileUpload={this.uploadFileToProject.bind(this)}
           />
           <RunSettingsDialog
             open={this.state.settingsDialogOpen}
-            onOk={this.closeRunSettingsDialog.bind(this)}
-            onCancel={this.closeRunSettingsDialog.bind(this)}
+            onOk={() => this.updateState({ settingsDialogOpen: false })}
+            onCancel={() => this.updateState({ settingsDialogOpen: false })}
             loading={this.state.loading || this.state.preprocessing}
             updateRunParams={this.updateRunParams.bind(this)}
             runParams={this.state.runParams}
@@ -5813,7 +5613,7 @@ class App extends React.Component {
           />
           <ImportProjectDialog
             open={this.state.importProjectDialogOpen}
-            onOk={this.closeImportDialog.bind(this)}
+            onOk={() => this.updateState({ importProjectDialogOpen: false })}
             loading={this.state.loading || this.state.uploading}
             importProject={this.importProject.bind(this)}
             fileUpload={this.uploadFileToFolder.bind(this)}
@@ -5822,7 +5622,7 @@ class App extends React.Component {
           />
           <ImportMXWDialog
             open={this.state.importMXWDialogOpen}
-            onOk={this.closeImportMXWDialog.bind(this)}
+            onOk={() => this.updateState({ importMXWDialogOpen: false })}
             loading={this.state.loading || this.state.preprocessing}
             importMXWProject={this.importMXWProject.bind(this)}
             fileUpload={this.uploadFileToFolder.bind(this)}
@@ -5832,8 +5632,8 @@ class App extends React.Component {
           <ResetDialog
             open={this.state.resetDialogOpen}
             onOk={this.resetServer.bind(this)}
-            onCancel={this.closeResetDialog.bind(this)}
-            onRequestClose={this.closeResetDialog.bind(this)}
+            onCancel={() => this.updateState({ resetDialogOpen: false })}
+            onRequestClose={() => this.updateState({ resetDialogOpen: false })}
             loading={this.state.loading}
           />
           <RunLogDialog
@@ -5854,15 +5654,15 @@ class App extends React.Component {
             onOk={this.closeServerDetailsDialog.bind(this)}
             onCancel={this.closeServerDetailsDialog.bind(this)}
             onRequestClose={this.closeServerDetailsDialog.bind(this)}
+            updateState={this.updateState.bind(this)}
             marxanServer={this.state.marxanServer}
             newWDPAVersion={this.state.newWDPAVersion}
-            showUpdateWDPADialog={this.openWDPAUpdateDialog.bind(this)}
             registry={this.state.registry}
           />
           <UpdateWDPADialog
             open={this.state.updateWDPADialogOpen}
-            onOk={this.closeWDPAUpdateDialog.bind(this)}
-            onCancel={this.closeWDPAUpdateDialog.bind(this)}
+            onOk={() => this.updateState({ updateWDPADialogOpen: false })}
+            onCancel={() => this.updateState({ updateWDPADialogOpen: false })}
             newWDPAVersion={this.state.newWDPAVersion}
             updateWDPA={this.updateWDPA.bind(this)}
             loading={this.state.preprocessing}
@@ -5879,7 +5679,7 @@ class App extends React.Component {
           />
           <AlertDialog
             open={this.state.alertDialogOpen}
-            onOk={this.closeAlertDialog.bind(this)}
+            onOk={() => this.updateState({ alertDialogOpen: false })}
           />
           <Snackbar
             open={this.state.snackbarOpen}
@@ -5901,7 +5701,12 @@ class App extends React.Component {
             >
               <MenuItemWithButton
                 leftIcon={<Properties style={{ margin: "1px" }} />}
-                onClick={this.openInfoDialog.bind(this)}
+                onClick={() =>
+                  this.updateState({
+                    openInfoDialogOpen: true,
+                    featureMenuOpen: false,
+                  })
+                }
               >
                 Properties
               </MenuItemWithButton>
@@ -6024,7 +5829,7 @@ class App extends React.Component {
           />
           <ShareableLinkDialog
             open={this.state.shareableLinkDialogOpen}
-            onOk={this.closeShareableLinkDialog.bind(this)}
+            onOk={() => this.updateState({ shareableLinkDialogOpen: false })}
             shareableLinkUrl={
               window.location +
               "?server=" +

--- a/src/CostsDialog.js
+++ b/src/CostsDialog.js
@@ -39,7 +39,9 @@ class CostsDialog extends React.Component {
         bodyStyle={{ padding: "0px 24px 0px 24px" }}
         offsetY={80}
         title="Costs"
-        onRequestClose={this.props.closeCostsDialog}
+        onRequestClose={() =>
+          this.props.updateState({ costsDialogOpen: false })
+        }
         helpLink={"user.html#importing-a-cost-surface"}
         children={
           <React.Fragment key="k8">
@@ -80,7 +82,9 @@ class CostsDialog extends React.Component {
                 icon={<Import style={{ height: "20px", width: "20px" }} />}
                 title="Upload a new costs file"
                 disabled={this.props.loading}
-                onClick={this.props.openImportCostsDialog.bind(this)}
+                onClick={() =>
+                  this.props.updateState({ importCostsDialogOpen: true })
+                }
                 label={"Import"}
               />
               <ToolbarButton

--- a/src/FeatureDialog.js
+++ b/src/FeatureDialog.js
@@ -40,7 +40,9 @@ class FeatureDialog extends React.Component {
     return (
       <MarxanDialog
         {...this.props}
-        onRequestClose={this.props.onCancel}
+        onRequestClose={() =>
+          this.props.updateState({ featureDialogOpen: false })
+        }
         showCancelButton={false}
         title={this.props.feature_metadata.alias}
         helpLink={"user.html#the-feature-details-window"}

--- a/src/FeaturesDialog.js
+++ b/src/FeaturesDialog.js
@@ -42,23 +42,30 @@ class FeaturesDialog extends React.Component {
   }
   showNewFeaturePopover(event) {
     this.setState({ newFeatureAnchor: event.currentTarget });
-    this.props.showNewFeaturePopover();
+    this.props.updateState({ newFeaturePopoverOpen: true });
   }
   showImportFeaturePopover(event) {
     this.setState({ importFeatureAnchor: event.currentTarget });
-    this.props.showImportFeaturePopover();
+    this.props.updateState({ importFeaturePopoverOpen: true });
   }
   _openImportFeaturesDialog() {
-    //close the dialog
-    this.props.onCancel();
-    //show the new feature dialog
-    this.props.openImportFeaturesDialog("import");
+    // close the dialog
+    // and show the new feature dialog
+    this.props.updateState({
+      featuresDialogOpen: false,
+      newFeaturePopoverOpen: false,
+      importFeaturePopoverOpen: false,
+      importFeaturesDialogOpen: true,
+    });
   }
   _openImportFromWebDialog() {
-    //close the dialog
-    this.props.onCancel();
-    //show the new feature dialog
-    this.props.openImportFromWebDialog();
+    //close the dialog & show new dialog
+    this.props.updateState({
+      featuresDialogOpen: false,
+      newFeaturePopoverOpen: false,
+      importFeaturePopoverOpen: false,
+      importFromWebDialogOpen: true,
+    });
   }
   _newByDigitising() {
     //hide this dialog
@@ -67,8 +74,12 @@ class FeaturesDialog extends React.Component {
     this.props.initialiseDigitising();
   }
   openImportGBIFDialog() {
-    this.props.openImportGBIFDialog();
-    this.props.onCancel();
+    this.props.updateState({
+      importGBIFDialogOpen: true,
+      featuresDialogOpen: false,
+      newFeaturePopoverOpen: false,
+      importFeaturePopoverOpen: false,
+    });
   }
   clickFeature(event, rowInfo) {
     //if adding or removing features from a project
@@ -81,7 +92,7 @@ class FeaturesDialog extends React.Component {
           rowInfo
         );
         //update the selected ids
-        this.props.selectFeatures(selectedIds);
+        this.props.update(selectedIds);
       } else {
         //single feature has been clicked
         this.props.clickFeature(
@@ -145,7 +156,7 @@ class FeaturesDialog extends React.Component {
       this.filteredRows.forEach((feature) => {
         selectedIds.push(feature.id);
       });
-      this.props.selectFeatures(selectedIds);
+      this.props.updateState({ selectedFeatureIds: selectedIds });
     } else {
       //select all features
       this.props.selectAllFeatures();
@@ -162,7 +173,11 @@ class FeaturesDialog extends React.Component {
     this.setState({
       selectedFeature: undefined,
     });
-    this.props.onCancel();
+    this.props.updateState({
+      featuresDialogOpen: false,
+      newFeaturePopoverOpen: false,
+      importFeaturePopoverOpen: false,
+    });
   }
   sortDate(a, b, desc) {
     return new Date(
@@ -350,7 +365,9 @@ class FeaturesDialog extends React.Component {
                   anchorEl={this.state.newFeatureAnchor}
                   anchorOrigin={{ horizontal: "left", vertical: "bottom" }}
                   targetOrigin={{ horizontal: "left", vertical: "top" }}
-                  onRequestClose={this.props.hideNewFeaturePopover}
+                  onRequestClose={() =>
+                    this.props.updateState({ newFeaturePopoverOpen: false })
+                  }
                 >
                   <Menu desktop={true}>
                     <MenuItem
@@ -377,7 +394,9 @@ class FeaturesDialog extends React.Component {
                   anchorEl={this.state.importFeatureAnchor}
                   anchorOrigin={{ horizontal: "left", vertical: "bottom" }}
                   targetOrigin={{ horizontal: "left", vertical: "top" }}
-                  onRequestClose={this.props.hideImportFeaturePopover}
+                  onRequestClose={() =>
+                    this.props.updateState({ importFeaturePopoverOpen: false })
+                  }
                 >
                   <Menu desktop={true}>
                     <MenuItem
@@ -435,7 +454,9 @@ class FeaturesDialog extends React.Component {
                   show={this.props.addingRemovingFeatures}
                   icon={<FontAwesomeIcon icon={faCircle} />}
                   title="Clear all features"
-                  onClick={this.props.clearAllFeatures}
+                  onClick={() =>
+                    this.props.updateState({ selectedFeatureIds: [] })
+                  }
                   label={"Clear all"}
                 />
                 <ToolbarButton

--- a/src/ImportCostsDialog.js
+++ b/src/ImportCostsDialog.js
@@ -25,7 +25,7 @@ class ImportCostsDialog extends React.Component {
     //reset the import cost state
     this.resetState();
     //close the dialog
-    this.props.closeImportCostsDialog();
+    this.props.updateState({ importCostsDialogOpen: false });
   }
   setCostsFilename(filename) {
     this.setState({
@@ -38,7 +38,7 @@ class ImportCostsDialog extends React.Component {
       //reset the import cost state
       this.resetState();
       //close the dialog
-      this.props.closeImportCostsDialog();
+      this.props.updateState({ importCostsDialogOpen: false });
     });
   }
   render() {

--- a/src/ImportFeaturesDialog.js
+++ b/src/ImportFeaturesDialog.js
@@ -83,13 +83,20 @@ class ImportFeaturesDialog extends React.Component {
         this.closeDialog();
       });
   }
+
+  setFilename(filename) {
+    this.props.updateState({ featureDatasetFilename: filename });
+  }
+
   closeDialog() {
     //delete the zip file and shapefile
     this.props.deleteShapefile(this.props.filename, this.shapefile);
     this.setState(INITIAL_STATE);
     this.shapefile = "";
-    this.props.setFilename("");
-    this.props.onCancel();
+    this.props.updateState({
+      featureDatasetFilename: "",
+      importFeaturesDialogOpen: false,
+    });
   }
   render() {
     let _disabled = false;
@@ -152,7 +159,7 @@ class ImportFeaturesDialog extends React.Component {
               fileMatch={".zip"}
               mandatory={true}
               filename={this.props.filename}
-              setFilename={this.props.setFilename}
+              setFilename={this.setFilename.bind(this)}
               destFolder={"imports"}
               label="Shapefile"
               style={{ paddingTop: "10px" }}

--- a/src/ImportFromWebDialog.js
+++ b/src/ImportFromWebDialog.js
@@ -141,7 +141,7 @@ class ImportFromWebDialog extends React.Component {
   }
   closeDialog() {
     this.setState(INITIAL_STATE);
-    this.props.onCancel();
+    this.props.onCancel({ importFromWebDialogOpen: false });
   }
   render() {
     let _disabled = false;

--- a/src/ImportGBIFDialog.js
+++ b/src/ImportGBIFDialog.js
@@ -20,10 +20,10 @@ class ImportGBIFDialog extends React.Component {
     this.props
       .importGBIFData(this.state.selectedItem)
       .then((response) => {
-        this.props.onCancel();
+        this.props.updateState({ importGBIFDialogOpen: false });
       })
       .catch((error) => {
-        this.props.onCancel();
+        this.props.updateState({ importGBIFDialogOpen: false });
       });
   }
   changeSearchText(event, value) {

--- a/src/InfoPanel.js
+++ b/src/InfoPanel.js
@@ -108,7 +108,7 @@ class InfoPanel extends React.Component {
     //get the costname
     let costname = this.costnames[key];
     if (costname === "Custom..") {
-      this.props.openCostsDialog();
+      this.props.updateState({ costsDialogOpen: true });
     } else {
       //update the cost profile on the server
       this.props.changeCostname(costname).then((_) => {
@@ -446,7 +446,9 @@ class InfoPanel extends React.Component {
               <ToolbarButton
                 icon={<Settings style={{ height: "20px", width: "20px" }} />}
                 title="Run Settings"
-                onClick={this.props.showRunSettingsDialog}
+                onClick={() =>
+                  this.props.updateState({ settingsDialogOpen: true })
+                }
               />
               <div className="toolbarSpacer" />
               <ToolbarButton

--- a/src/LoginDialog.js
+++ b/src/LoginDialog.js
@@ -143,7 +143,7 @@ class LoginDialog extends React.Component {
                   }
                   onKeyPress={this.handleKeyPress.bind(this)}
                 />
-                {/*<span onClick={this.props.openResendPasswordDialog.bind(this)} className="forgotLink" title="Click to resend password">Forgot</span>*/}
+                {/*<span onClick={() => this.props.updateState({ resendPasswordDialogOpen: true })} className="forgotLink" title="Click to resend password">Forgot</span>*/}
               </div>
               <div
                 style={{

--- a/src/NewProjectDialog.js
+++ b/src/NewProjectDialog.js
@@ -65,7 +65,7 @@ class NewProjectDialog extends React.Component {
   }
   onOk(evt) {
     this.gotoStart();
-    this.props.onOk();
+    this.props.updateState({ newProjectDialogOpen: false });
   }
   gotoStart() {
     //reset to the beginning
@@ -153,6 +153,10 @@ class NewProjectDialog extends React.Component {
     this.onOk();
   }
 
+  openCostsDialog() {
+    this.props.updateState({ costsDialogOpen: true });
+  }
+
   render() {
     const { stepIndex } = this.state;
     const contentStyle = { margin: "0 16px" };
@@ -236,7 +240,7 @@ class NewProjectDialog extends React.Component {
         ) : null}
         {stepIndex === 3 ? (
           <SelectCostFeatures
-            openCostsDialog={this.props.openCostsDialog}
+            openCostsDialog={this.openCostsDialog}
             selectedCosts={this.props.selectedCosts}
           />
         ) : null}

--- a/src/NewProjectWizardDialog.js
+++ b/src/NewProjectWizardDialog.js
@@ -322,8 +322,12 @@ class NewProjectWizardDialog extends React.Component {
         title={"New national project"}
         contentWidth={600}
         showCancelButton={true}
-        onCancel={this.props.closeNewProjectWizardDialog}
-        onRequestClose={this.props.closeNewProjectWizardDialog}
+        onCancel={() =>
+          this.props.updateState({ newProjectWizardDialogOpen: false })
+        }
+        onRequestClose={() =>
+          this.props.updateState({ newProjectWizardDialogOpen: false })
+        }
         helpLink={"user.html#creating-new-projects"}
         actions={actions}
         children={children}

--- a/src/PlanningGridDialog.js
+++ b/src/PlanningGridDialog.js
@@ -38,7 +38,11 @@ class PlanningGridDialog extends React.Component {
     return (
       <MarxanDialog
         {...this.props}
-        onRequestClose={this.props.onCancel}
+        onRequestClose={() =>
+          this.props.updateState({
+            planningGridDialogOpen: false,
+          })
+        }
         showCancelButton={false}
         title={this.props.planning_grid_metadata.alias}
         helpLink={"user.html#the-planning-grid-details-window"}

--- a/src/PlanningGridsDialog.js
+++ b/src/PlanningGridsDialog.js
@@ -34,7 +34,7 @@ class PlanningGridsDialog extends React.Component {
     this.closeDialog();
   }
   openImportDialog() {
-    this.props.openImportPlanningGridDialog();
+    this.props.updateState({ importPlanningGridDialogOpen: true });
     this.closeDialog();
   }
   exportPlanningGrid() {
@@ -50,7 +50,7 @@ class PlanningGridsDialog extends React.Component {
   }
   closeDialog() {
     this.setState({ selectedPlanningGrid: undefined });
-    this.props.onOk();
+    this.props.updateState({ planningGridsDialogOpen: false });
   }
   preview(planning_grid_metadata) {
     this.props.previewPlanningGrid(planning_grid_metadata);

--- a/src/ProjectsDialog.js
+++ b/src/ProjectsDialog.js
@@ -58,13 +58,13 @@ class ProjectsDialog extends React.Component {
   }
   showImportProjectPopover(event) {
     this.setState({ importProjectAnchor: event.currentTarget });
-    this.props.showImportProjectPopover();
+    this.props.updateState({ importProjectPopoverOpen: true });
   }
   _new() {
     //get all the features again otherwise the allFeatures state may be bound to an old version of marxans features
     this.props.getAllFeatures().then(
       function () {
-        this.props.openNewProjectDialog();
+        this.props.updateState({ newProjectDialogOpen: true });
         this.closeDialog();
       }.bind(this)
     );
@@ -87,11 +87,11 @@ class ProjectsDialog extends React.Component {
     this.closeDialog();
   }
   openImportProjectDialog() {
-    this.props.openImportProjectDialog();
+    this.props.updateState({ importProjectDialogOpen: true });
     this.closeDialog();
   }
   openImportMXWDialog() {
-    this.props.openImportMXWDialog();
+    this.props.updateState({ importMXWDialogOpen: true });
     this.closeDialog();
   }
   changeProject(event, project) {
@@ -99,7 +99,10 @@ class ProjectsDialog extends React.Component {
   }
   closeDialog() {
     this.setState({ selectedProject: undefined });
-    this.props.onOk();
+    this.props.updateState({
+      projectsDialogOpen: false,
+      importProjectPopoverOpen: false,
+    });
   }
   sortDate(a, b, desc) {
     return new Date(
@@ -305,7 +308,9 @@ class ProjectsDialog extends React.Component {
                   anchorEl={this.state.importProjectAnchor}
                   anchorOrigin={{ horizontal: "left", vertical: "bottom" }}
                   targetOrigin={{ horizontal: "left", vertical: "top" }}
-                  onRequestClose={this.props.hideImportProjectPopover}
+                  onRequestClose={() =>
+                    this.props.updateState({ importProjectPopoverOpen: false })
+                  }
                 >
                   <Menu desktop={true}>
                     <MenuItem

--- a/src/RegisterDialog.js
+++ b/src/RegisterDialog.js
@@ -93,7 +93,9 @@ class RegisterDialog extends React.Component {
         helpLink={"user.html#new-user-registration"}
         title="Register"
         children={c}
-        onRequestClose={this.props.onCancel}
+        onRequestClose={() =>
+          this.props.updateState({ registerDialogOpen: false })
+        }
       />
     );
   }

--- a/src/ServerDetailsDialog.js
+++ b/src/ServerDetailsDialog.js
@@ -64,7 +64,7 @@ class ServerDetailsDialog extends React.Component {
             marginTop: "5px",
           }}
           title={"A new version of the WDPA is available - click for details"}
-          onClick={this.props.showUpdateWDPADialog}
+          onClick={() => this.props.updateState({ updateWDPADialogOpen: true })}
         />
       </React.Fragment>
     );

--- a/src/ToolsMenu.js
+++ b/src/ToolsMenu.js
@@ -31,7 +31,7 @@ class ToolsMenu extends React.Component {
     this.props.hideToolsMenu();
   }
   openResetDialog() {
-    this.props.openResetDialog();
+    this.props.updateState({ resetDialogOpen: true });
     this.props.hideToolsMenu();
   }
   render() {

--- a/src/Welcome.js
+++ b/src/Welcome.js
@@ -23,9 +23,10 @@ class Welcome extends React.Component {
   toggleShowWelcomeScreen(evt, isInputChecked) {
     this.setState({ checked: isInputChecked });
   }
+
   onOk() {
     this.props.saveOptions({ SHOWWELCOMESCREEN: this.state.checked });
-    this.props.onOk();
+    this.props.updateState({ welcomeDialogOpen: false });
   }
   openNewProjectDialog() {
     this.onOk();


### PR DESCRIPTION
I create a function 
```
updateState(state_obj) {
    this.setstate(state_obj)
}

// used like this
this.props.updateState({ importProjectPopoverOpen: false })
```

and then replaced a lot of the individual setState functions. 
Updated the components to match. 
This cuts down on code and moves some of the functionality to the components themselves. 
